### PR TITLE
Bugfix: Use the correct uri for the physical file uri

### DIFF
--- a/pricelist-export.js
+++ b/pricelist-export.js
@@ -108,6 +108,6 @@ export default async function exportPricelist(includeNonListed, graph) {
     size: filestats.size,
     created: filestats.birthtime
   };
-  const muFile = await createFile(csvFile, fileToSharedUri(filePath), querySudo, graph);
+  const muFile = await createFile(csvFile, fileUri, querySudo, graph);
   return muFile;
 }


### PR DESCRIPTION
The wrong uri was passed to `createFile`. this should be the physicalFile uri.